### PR TITLE
make install-unpacked flattens the python hierarchy so result doesn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,8 @@ all: oxt
 
 install-unpacked: extension-files
 	install -m 755 -d "$(DESTDIR)" "$(DESTDIR)/META-INF"
-	install -m 644 build/oxt/META-INF/manifest.xml "$(DESTDIR)/META-INF"
-	install -m 644 build/oxt/description.xml \
-	               $(patsubst %,build/oxt/%,$(STANDALONE_EXTENSION_FILES)) \
-	               $(patsubst %,build/oxt/%,$(COPY_TEMPLATES)) $(DESTDIR)
+	install -m 755 -d "$(DESTDIR)" "$(DESTDIR)/pythonpath"
+	cd oxt && find . -type f -exec install -D {} $(DESTDIR)/{} \;
 
 # Sed scripts for modifying templates
 DESCRIPTION_SEDSCRIPT:=s/VOIKKO_VERSION/$(VOIKKO_VERSION)/g


### PR DESCRIPTION
the original oxt has the correct hierarchy but 'install' flattened it

Resolves:
https://github.com/voikko/libreoffice-voikko/issues/11
https://bugzilla.redhat.com/show_bug.cgi?id=1676830
https://bugs.documentfoundation.org/show_bug.cgi?id=122984